### PR TITLE
safety: add OnlySupported mode for convenience

### DIFF
--- a/landlock.go
+++ b/landlock.go
@@ -15,8 +15,13 @@ import (
 type Safety byte
 
 const (
-	// Mandatory mode will return an error on failure.
+	// Mandatory mode will return an error on failure, including on
+	// systems where landlock is not supported.
 	Mandatory Safety = iota
+
+	// OnlySupported will return an error on failure if running
+	// on a supported operating system, or no error otherwise
+	OnlySupported
 
 	// Try mode will continue with no error on failure.
 	Try

--- a/landlock_default.go
+++ b/landlock_default.go
@@ -24,6 +24,8 @@ func New(...*Path) Locker {
 
 func (l *locker) Lock(s Safety) error {
 	switch s {
+	case OnlySupported:
+		return nil
 	case Try:
 		return nil
 	case Mandatory:

--- a/landlock_default_test.go
+++ b/landlock_default_test.go
@@ -22,6 +22,12 @@ func TestLocker_Lock_Try(t *testing.T) {
 	must.NoError(t, err)
 }
 
+func TestLocker_Lock_OnlySupported(t *testing.T) {
+	l := New()
+	err := l.Lock(OnlySupported)
+	must.NoError(t, err)
+}
+
 func TestLocker_String(t *testing.T) {
 	l := New()
 	s := l.String()


### PR DESCRIPTION
Previously there were Mandatory and Try modes, but now we have OnlySupported which only returns an error on locking if we are running on a supported system (Linux). This should help cleanup callers of landlock, so that we can use the interface directly without using build tags (ignoring helpers for now).