### PR TITLE
lint: use skip-cache in golangci-lint

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,7 @@ jobs:
       - uses: golangci/golangci-lint-action@v3
         with:
           version: v1.50
+          skip-cache: true
       - name: Run Go Test
         run: |
           go test -race -v ./...


### PR DESCRIPTION
Maybe this will stop the "file already exists" warnings