### PR TITLE
caps: add support for file truncate with landlock v3

### DIFF
--- a/landlock_linux_test.go
+++ b/landlock_linux_test.go
@@ -281,6 +281,8 @@ func TestLocker_writes(t *testing.T) {
 }
 
 func TestLocker_truncate(t *testing.T) {
+	requiresVersion(t, 3)
+
 	cases := map[string]func(){
 		"truncate_none": func() {
 			f := tmpFile(t, "hi.txt", "hello")
@@ -744,5 +746,11 @@ func forkAndRunEachCase(t *testing.T, prefix string, cases map[string]func()) {
 		b, err := cmd.CombinedOutput()
 		t.Logf("TEST[%s] (arg: %s)\n\t|> %s\n\n", name, arg, string(b))
 		must.NoError(t, err)
+	}
+}
+
+func requiresVersion(t *testing.T, v int) {
+	if version < v {
+		t.Skipf("version of landlock not high enough for test; need %d, got %d", v, version)
 	}
 }

--- a/path.go
+++ b/path.go
@@ -47,7 +47,7 @@ func (p *Path) Hash() string {
 }
 
 func (p *Path) String() string {
-	kind := IfElse(p.dir, "dir", "file")
+	kind := ifelse(p.dir, "dir", "file")
 	return fmt.Sprintf("(%s:%s:%s)", p.mode, kind, p.path)
 }
 
@@ -119,7 +119,7 @@ func parsePath(filetype, mode, path string) (*Path, error) {
 	case !IsProperPath(path):
 		return nil, ErrImproperPath
 	}
-	dir := IfElse(filetype == "d", true, false)
+	dir := ifelse(filetype == "d", true, false)
 	return &Path{
 		mode: mode,
 		path: path,
@@ -153,7 +153,7 @@ func IsProperPath(path string) bool {
 	return path != ""
 }
 
-func IfElse[T any](condition bool, result T, otherwise T) T {
+func ifelse[T any](condition bool, result T, otherwise T) T {
 	if condition {
 		return result
 	}

--- a/path_linux.go
+++ b/path_linux.go
@@ -14,14 +14,15 @@ func (p *Path) access() rule {
 			directory := fsReadFile | fsReadDir
 			allow |= ifelse(p.dir, directory, fsReadFile)
 		case 'w':
-			allow |= fsWriteFile | fsTruncate
+			allow |= fsWriteFile
+			allow |= ifelse(version >= 3, fsTruncate, 0)
 		case 'x':
 			allow |= fsExecute
 		case 'c':
 			directory := fsMakeRegular | fsMakeSocket | fsMakeFifo | fsMakeBlock |
 				fsMakeSymlink | fsMakeDir | fsRemoveFile | fsRemoveDir
 			allow |= ifelse(p.dir, directory, 0)
-			allow |= ifelse(p.dir && version > 1, fsRefer, 0)
+			allow |= ifelse(p.dir && version >= 2, fsRefer, 0)
 		}
 	}
 	return allow

--- a/path_linux.go
+++ b/path_linux.go
@@ -14,7 +14,7 @@ func (p *Path) access() rule {
 			directory := fsReadFile | fsReadDir
 			allow |= IfElse(p.dir, directory, fsReadFile)
 		case 'w':
-			allow |= fsWriteFile
+			allow |= fsWriteFile | fsTruncate
 		case 'x':
 			allow |= fsExecute
 		case 'c':

--- a/path_linux.go
+++ b/path_linux.go
@@ -12,7 +12,7 @@ func (p *Path) access() rule {
 		switch c {
 		case 'r':
 			directory := fsReadFile | fsReadDir
-			allow |= IfElse(p.dir, directory, fsReadFile)
+			allow |= ifelse(p.dir, directory, fsReadFile)
 		case 'w':
 			allow |= fsWriteFile | fsTruncate
 		case 'x':
@@ -20,8 +20,8 @@ func (p *Path) access() rule {
 		case 'c':
 			directory := fsMakeRegular | fsMakeSocket | fsMakeFifo | fsMakeBlock |
 				fsMakeSymlink | fsMakeDir | fsRemoveFile | fsRemoveDir
-			allow |= IfElse(p.dir, directory, 0)
-			allow |= IfElse(p.dir && version > 1, fsRefer, 0)
+			allow |= ifelse(p.dir, directory, 0)
+			allow |= ifelse(p.dir && version > 1, fsRefer, 0)
 		}
 	}
 	return allow

--- a/syscall_linux.go
+++ b/syscall_linux.go
@@ -37,6 +37,7 @@ const (
 	fsMakeBlock   rule = unix.LANDLOCK_ACCESS_FS_MAKE_BLOCK
 	fsMakeSymlink rule = unix.LANDLOCK_ACCESS_FS_MAKE_SYM
 	fsRefer       rule = unix.LANDLOCK_ACCESS_FS_REFER
+	fsTruncate    rule = unix.LANDLOCK_ACCESS_FS_TRUNCATE
 )
 
 func abi() (int, error) {
@@ -67,6 +68,9 @@ func capabilities() rule {
 		fsMakeFifo | fsMakeBlock | fsMakeSymlink
 	if version >= 2 {
 		opts |= fsRefer
+	}
+	if version >= 3 {
+		opts |= fsTruncate
 	}
 	return opts
 }


### PR DESCRIPTION
This PR adds support for the ACCESS_FS_TRUNCATE landlock rule
added in landlock v3 (Linux 6.2). If a file or directory is
added to a lock set with the 'w' permission, that file or files
in that directory can now be truncated (e.g. with os.Truncate).
