### PR TITLE
option only available

### DIFF
--- a/landlock.go
+++ b/landlock.go
@@ -19,9 +19,17 @@ const (
 	// systems where landlock is not supported.
 	Mandatory Safety = iota
 
-	// OnlySupported will return an error on failure if running
-	// on a supported operating system, or no error otherwise
+	// OnlySupported will return an error on failure if running on a supported
+	// operating system (Linux), or no error otherwise. Unlike OnlyAvailable,
+	// this includes returning an error on systems where the Linux kernel was
+	// built without landlock support.
 	OnlySupported
+
+	// OnlyAvailable will return an error on failure if running in an environment
+	// where landlock is detected and available, or no error otherwise. Unlike
+	// OnlySupported, OnlyAvailable does not cause an error on Linux systems built
+	// without landlock support.
+	OnlyAvailable
 
 	// Try mode will continue with no error on failure.
 	Try

--- a/landlock_default.go
+++ b/landlock_default.go
@@ -24,6 +24,8 @@ func New(...*Path) Locker {
 
 func (l *locker) Lock(s Safety) error {
 	switch s {
+	case OnlyAvailable:
+		return nil
 	case OnlySupported:
 		return nil
 	case Try:


### PR DESCRIPTION
This PR adds the `OnlyAvailable` locking mode for cases where we just want
to attempt to lock (with errors) in cases where landlock is actually
detected to be available. Useful for running on kernels where landlock
may or may not be enabled and we don't really care.