### PR TITLE
path: add /usr/libexec to shared paths

### DIFF
--- a/path_linux.go
+++ b/path_linux.go
@@ -48,6 +48,7 @@ func init() {
 		Dir("/lib", "rx"),
 		Dir("/lib64", "rx"),
 		Dir("/usr/lib", "rx"),
+		Dir("/usr/libexec", "rx"),
 		Dir("/usr/local/lib", "rx"),
 		Dir("/usr/local/lib64", "rx"),
 		File("/etc/ld.so.conf", "r"),


### PR DESCRIPTION
Closes #49 